### PR TITLE
Ahora se pueden pasar argumentos de inicio

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,26 @@
-var SgCnf = require('./lib/SgCnf.js');
-if (SgCnf.profile === 'server'){
-	var SgServer = require('./lib/SgServer.js');
-	console.log(SgServer);
-}
-else if (SgCnf.profile === 'client'){
-	var SgCliente = require('./lib/SgCliente.js');
-	console.log(SgCliente);
+var SgCnf = require('./lib/SgCnf');
+var sgClient;
+
+
+// get the second argument passed
+// in an invocation like $> node index server
+// the process.argv array would be filled with
+// ['node', 'index', 'server']
+// so we take the second parameter to see if we need
+// to instance a server or a client
+if(process.argv[2] && typeof process.argv[2] === 'string'){
+
+	switch(process.argv[2]){
+		case 'server':
+			sgClient = require('./lib/SgServer');
+		break;
+
+		//client
+		default:
+			sgClient = require('./lib/SgCliente');
+	}
+
+}else{
+	sgClient = require('./lib/SgCliente');
 }
 


### PR DESCRIPTION
Se pueden pasar los argumentos 'server' o 'client' para ejecutar el programa como servidor o cliente respectivamente.

Para ejecutar como servidor: $> node index server
Para ejecutar como cliente: $> node index, ó $> node index client
